### PR TITLE
feat: add localStorage persistence for favorites

### DIFF
--- a/frontend/src/components/GiftRecommender.jsx
+++ b/frontend/src/components/GiftRecommender.jsx
@@ -1,7 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { GiftCard } from './GiftCard';
 import { GiftForm } from './GiftForm';
-import { parseRecommendations } from './utils';
+import { parseRecommendations, saveFavorites, loadFavorites } from './utils';
 
 export const GiftRecommender = () => {
   const [isCoalMode, setIsCoalMode] = useState(false);
@@ -11,6 +11,14 @@ export const GiftRecommender = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [showFavorites, setShowFavorites] = useState(false);
+
+  useEffect(() => {
+    const savedFavorites = loadFavorites();
+    if (savedFavorites.length > 0) {
+      setFavorites(savedFavorites);
+    }
+  }, []);
+
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -56,9 +64,11 @@ export const GiftRecommender = () => {
   const handleFavorite = (gift) => {
     setFavorites(prevFavorites => {
       const isAlreadyFavorite = prevFavorites.some(fav => fav.id === gift.id);
-      return isAlreadyFavorite
+      const newFavorites = isAlreadyFavorite
         ? prevFavorites.filter(fav => fav.id !== gift.id)
         : [...prevFavorites, gift];
+        saveFavorites(newFavorites);
+      return newFavorites;
     });
   };
 

--- a/frontend/src/components/utils.jsx
+++ b/frontend/src/components/utils.jsx
@@ -12,3 +12,20 @@ export const parseRecommendations = (text) => {
       };
     });
   };
+  export const saveFavorites = (favorites) => {
+    try {
+      localStorage.setItem('giftFavorites', JSON.stringify(favorites));
+    } catch (error) {
+      console.error('Error saving favorites:', error);
+    }
+  };
+  
+  export const loadFavorites = () => {
+    try {
+      const favorites = localStorage.getItem('giftFavorites');
+      return favorites ? JSON.parse(favorites) : [];
+    } catch (error) {
+      console.error('Error loading favorites:', error);
+      return [];
+    }
+  };


### PR DESCRIPTION
## Changes Made
- Added localStorage functionality to persist favorites
- Added loadFavorites utility function to restore saved favorites
- Added saveFavorites utility function to save favorites
- Updated GiftRecommender to load/save favorites automatically
- Maintained all existing Christmas theming and coal mode functionality

## Testing Completed
- [x] Favorites persist after page refresh
- [x] Can add new favorites
- [ x] Can remove favorites
- [ x] Favorites count updates correctly
- [ x] Christmas theme preserved
- [x ] Coal mode working correctly
- [x ] No console errors

## Additional Notes
This PR adds persistence to the favorites feature while maintaining the existing Christmas UI and functionality.